### PR TITLE
Feat: Add `uploadRatioTarget` setting to the configuration page

### DIFF
--- a/src/modules/joal-api/settings/settings.reducer.ts
+++ b/src/modules/joal-api/settings/settings.reducer.ts
@@ -17,7 +17,8 @@ const initialState: Settings = {
     maxUploadRate: 0,
     simultaneousSeed: 0,
     client: '',
-    keepTorrentWithZeroLeechers: false
+    keepTorrentWithZeroLeechers: false,
+    uploadRatioTarget: -1
   },
   availableClients: []
 };

--- a/src/modules/joal-api/types.ts
+++ b/src/modules/joal-api/types.ts
@@ -39,7 +39,8 @@ export interface Config {
   maxUploadRate: number,
   simultaneousSeed: number,
   client: string,
-  keepTorrentWithZeroLeechers: boolean
+  keepTorrentWithZeroLeechers: boolean,
+  uploadRatioTarget: number
 }
 
 export interface Settings {

--- a/src/pages/settings/settings.component.tsx
+++ b/src/pages/settings/settings.component.tsx
@@ -147,7 +147,7 @@ const Settings = (props: Props) => {
                 className={classes.formInput}
                 label="Upload ratio target"
                 type="number"
-                inputProps={{ min:-1 }}
+                inputProps={{ min:-1, step: config.uploadRatioTarget > 0 ? 0.1 : 1 }}
                 helperText="Set to -1.0 for indefinite seeding. Note: Uploaded amount resets to 0 upon Joal restart."
                 value={config.uploadRatioTarget}
                 onChange={(event) => {

--- a/src/pages/settings/settings.component.tsx
+++ b/src/pages/settings/settings.component.tsx
@@ -143,6 +143,20 @@ const Settings = (props: Props) => {
               />
             </Grid>
             <Grid item xs={12}>
+              <TextField
+                className={classes.formInput}
+                label="Upload ratio target"
+                type="number"
+                inputProps={{ min:-1 }}
+                helperText="Set to -1.0 for indefinite seeding. Note: Uploaded amount resets to 0 upon Joal restart."
+                value={config.uploadRatioTarget}
+                onChange={(event) => {
+                  const value = event.target.value === '' ? '' : event.target.value;
+                  valueHasChanged({ uploadRatioTarget: value });
+                }}
+              />
+            </Grid>
+            <Grid item xs={12}>
               <div className={classes.formInput}>
                 <FormControlLabel
                   control={(


### PR DESCRIPTION
Add the `uploadRatioTarget` in the configuration page according to the newly created setting on the main app [PR on `anthonyraymond/joal` #221](https://github.com/anthonyraymond/joal/pull/221)
